### PR TITLE
feat: random user functionality separate from the Get button

### DIFF
--- a/src/Components/Game.js
+++ b/src/Components/Game.js
@@ -37,11 +37,9 @@ export default function Game() {
                     user_no === '1' ? setHideInput2(false) : setHideInput2(true);
                 } else {
                     fetchRandomUser(user_no);
-
                 }
             });
     }
-
 
     const fetchUser = (user_no) => {
         fetch(`https://api.github.com/users/${user_no === '1' ? username1Ref.current.value : username2Ref.current.value}`)
@@ -52,9 +50,6 @@ export default function Game() {
                     user_no === '1' ? setUser1(data) : setUser2(data);
                     user_no === '1' ? setHideInput1(true) : setHideInput2(true);
                     user_no === '1' ? setHideInput2(false) : setHideInput2(true);
-                } else {
-                    fetchRandomUser(user_no);
-                    
                 }
             });
     };
@@ -89,6 +84,9 @@ export default function Game() {
                             <Button className="btn" onClick={() => fetchUser('1')}>
               Get
                             </Button>
+                            <Button className="btn" onClick={() => fetchRandomUser('1')}>
+                                Random
+                            </Button>
                         </InputGroup>
                     </div>
                     <Button className="btn" disabled={!hideInput1 || !hideInput2} onClick={()=>battle()}>Battle</Button>
@@ -115,6 +113,9 @@ export default function Game() {
                             />
                             <Button className="btn" onClick={() => fetchUser('2')}>
               Get
+                            </Button>
+                            <Button className="btn" onClick={() => fetchRandomUser('2')}>
+                                Random
                             </Button>
                         </InputGroup>
                     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,7 @@ body{
   border-color:var(--theme);
   color:var(--theme);
   font-size:20px;
+  padding: 6px 10px;
 }
 
 .input-group > input.form-control:focus{


### PR DESCRIPTION
## Fixes Issue #4 

## Changes proposed

<!-- List all the proposed changes in your PR -->

Separates the random and username get functionality into two separate buttons. Also had to alter the input field CSS to prevent text cut off on the placeholder for the 2nd username entry field.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

![Screenshot 2023-02-09 152857](https://user-images.githubusercontent.com/16384609/217857417-e945e712-22fe-426b-82a1-fde053506e59.png)

![Screenshot 2023-02-09 152917](https://user-images.githubusercontent.com/16384609/217857441-b48e4156-81ff-47b5-8c7d-85c5f693717e.png)
